### PR TITLE
Update GitHub Actions (2024-05)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 name: build
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,6 +72,10 @@ jobs:
       - name: Install packages (macOS)
         if: runner.os == 'macOS'
         run: brew install msakai/tap/liblbfgsb
+      - name: Add /opt/homebrew/lib as extra library directory
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        run: |
+          echo "extra-lib-dirs: [/opt/homebrew/lib]" >> ${{ matrix.stack_yaml }}
 
       - name: Install packages (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,9 +44,9 @@ jobs:
             stack_yaml: 'stack-ghc-9.4.yaml'
             flags: ''
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@v2
         id: setup-haskell
         name: Setup Haskell
         with:
@@ -54,7 +54,7 @@ jobs:
           enable-stack: true
           stack-version: 'latest'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Cache ~/.stack
         with:
           path: ${{ steps.setup-haskell.outputs.stack-root }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,6 +90,10 @@ jobs:
           stack --stack-yaml ${{ matrix.stack_yaml }} exec -- pacman -S --needed --noconfirm ${MINGW_PACKAGE_PREFIX}-lapack
           stack --stack-yaml ${{ matrix.stack_yaml }} exec -- pacman -U --noconfirm ${MINGW_PACKAGE_PREFIX}-liblbfgsb-3.0-1-any.pkg.tar.zst
 
+      - name: Build dependencies
+        run: |
+          stack --stack-yaml ${{ matrix.stack_yaml }} build --test --no-run-tests --bench --no-run-benchmarks --only-dependencies --flag nonlinear-optimization-ad:BuildSamplePrograms --flag nonlinear-optimization-backprop:BuildSamplePrograms ${{ matrix.flags }}
+
       - name: Build
         run: |
           stack --stack-yaml ${{ matrix.stack_yaml }} build --test --no-run-tests --bench --no-run-benchmarks --flag nonlinear-optimization-ad:BuildSamplePrograms --flag nonlinear-optimization-backprop:BuildSamplePrograms ${{ matrix.flags }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,6 +59,9 @@ jobs:
           enable-stack: true
           stack-version: 'latest'
 
+      - name: Setup stack
+        run: stack config set system-ghc --global true
+
       - uses: actions/cache@v4
         name: Cache ~/.stack
         with:


### PR DESCRIPTION
* update versions of actions
*  run actions only on pull requests and on push to the `master` branch
* use system GHC to reduce cache size
* add separate build step for dependencies